### PR TITLE
[Test] Skip preview deployment for PRs from fork

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,15 +3,24 @@ name: PR preview
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number'
+        required: true
+
+env:
+  PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}
 
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number }}
+  group: pr-preview-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   pr-preview:
-    name: "path: /pr/${{ github.event.pull_request.number }}"
+    name: "path: /pr/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}"
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +37,7 @@ jobs:
           folder: build
           clean: false
           single-commit: true
-          target-folder: pr/${{ github.event.pull_request.number }}
+          target-folder: pr/${{ env.PR_NUMBER }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get latest gh-pages commit SHA
@@ -108,7 +117,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const issueNumber = context.issue.number;
+            const issueNumber = context.issue?.number || parseInt(process.env.PR_NUMBER, 10);
 
             const comments = await github.paginate(
               github.rest.issues.listComments,
@@ -132,6 +141,6 @@ jobs:
         if: steps.deploy.outputs.deployment-status == 'success'
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ env.PR_NUMBER }}
           body: |
-            🔍 [PR preview](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.pull_request.number }}/)
+            🔍 [PR preview](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ env.PR_NUMBER }}/)

--- a/docs/tutorials/site_contributing.md
+++ b/docs/tutorials/site_contributing.md
@@ -243,6 +243,14 @@ https://<user>.github.io/<repository>/pr/<number>/
 A comment with the preview link is automatically added to the pull request after the GitHub Pages deployment is complete — both for the initial PR and for subsequent updates.
 If the site content hasn’t changed, the workflow exits early without posting a comment.
 
+#### Pull requests from forks
+
+Previews are not deployed automatically for pull requests opened from forked repositories, because GitHub Actions do not have permission to write to the `gh-pages` branch in this case.
+
+Maintainers can manually trigger the **PR preview** workflow from the **Actions** tab after reviewing the pull request.
+
+> **Tip:** In the left sidebar of the **Actions** tab, select **PR preview** → **Run workflow**, enter the pull request number, and click **Run workflow**.
+
 #### Cleaning up stale previews
 
 To avoid accumulating outdated previews, a GitHub Actions workflow included in the repository:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,9 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const isPr = process.env.GITHUB_EVENT_NAME === 'pull_request';
-// Extract PR number from GITHUB_REF, which looks like "refs/pull/123/merge"
-const prNumber = isPr ? process.env.GITHUB_REF.match(/^refs\/pull\/(\d+)\/merge$/)?.[1] : null;
+const prNumber = process.env.PR_NUMBER;
+const isPr = Boolean(prNumber);
 const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1];
 const branch = process.env.GITHUB_REF_NAME?.replace('refs/heads/', '');
 // true for any branch‐build in GHA, false locally (no env var)


### PR DESCRIPTION
As forks lack write access to gh-pages, the deployment is skipped, and maintainers can run a manual dispatch.