### PR TITLE
Resolve public fuzzy service incident

### DIFF
--- a/blog/2025-10-18-incident-disclosure.md
+++ b/blog/2025-10-18-incident-disclosure.md
@@ -9,6 +9,8 @@ tags: [incident, announcement, service disruption]
 
 On Saturday, October 18th, 2025, the public Rspamd DNSBL RBL feed and what's more important **public fuzzy** service was disrupted due to an unexpected server block by our hosting provider, Hetzner. This interruption affected hundreds of thousands of users and likely led to increased volumes of spam for many legitimate email services worldwide.
 
+**Edit**: as of October 27th, 2025, public fuzzy service has been relocated to Ionos and is now fully operational again.  There is no need to change Rspamd configuration to use the new server.
+
 <!--truncate-->
 
 ## What Happened

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,24 +4,6 @@ title: About Rspamd
 
 # About Rspamd
 
-:::danger URGENT: Service Disruption Notice
-
-**Incident Disclosure: Rspamd Public Service Temporary Suspension Due to Hosting Provider Actions**
-
-On Saturday, October 18th, 2025, the public Rspamd DNSBL RBL feed and what's more important **public fuzzy** service was disrupted due to an unexpected server block by our hosting provider, Hetzner. This interruption affected hundreds of thousands of users and likely led to increased volumes of spam for many legitimate email services worldwide.
-
-**[Read the full incident disclosure](/blog/2025/10/18/incident-disclosure)**
-
-**Summary:**
-- Service was blocked due to false positive detection by hosting provider
-- Despite multiple communications and clarifications, the block occurred
-- Services are currently being reviewed and will be migrated to a more robust provider
-- **✅ Positive Update:** Due to generous community support, we expect the public fuzzy service to be back online in approximately one week
-
-We regret the inconvenience and are grateful for the overwhelming support from the community.
-
-:::
-
 ## Introduction
 
 **Rspamd** is a high-performance email processing framework designed as an independent layer between your Mail Transfer Agent (MTA) and the internet. Operating outside MTA internal flows, Rspamd provides security isolation while delivering comprehensive message analysis, spam filtering, and policy enforcement.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -134,14 +134,6 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      announcementBar: {
-        id: 'incident_2025_10_18',
-        content:
-          '⚠️ <strong>Service Disruption Notice</strong> - Public fuzzy service temporarily suspended, expected back in ~1 week thanks to community support. <a href="/blog/2025/10/18/incident-disclosure" style="text-decoration: underline;">Read full disclosure</a>',
-        backgroundColor: '#fee2e2',
-        textColor: '#991b1b',
-        isCloseable: true,
-      },
       docs: {
         sidebar: {
           hideable: true,


### PR DESCRIPTION
According to my logs, the public fuzzy service is responding again since
the 25th of October.  The IP address of the fuzzy services are from a
range that belong to IONOS, so I assumed the services has been migrated
there and the incident is now resolved.  As such, the banners indicating
degraded services can be removed, and the blog post can be updated to
indicate that the service is now available again.
