### PR TITLE
Update documentation for antivirus module

### DIFF
--- a/docs/modules/antivirus.md
+++ b/docs/modules/antivirus.md
@@ -2,223 +2,375 @@
 title: Antivirus module
 ---
 
-
 # Antivirus module
 
-The Antivirus module, available from Rspamd version 1.4, seamlessly integrates with various virus scanners. Currently, the following scanners are supported:
+The Antivirus module, available from Rspamd version 1.4, integrates with various virus scanners. Currently, the following scanners are supported:
 
-* [Avast Antivirus Rest API](https://businesshelp.avast.com/Content/Products/AfB_Antivirus/Linux/InstallingAvastBusinessAntivirusLinux.htm) (from 3.3)
+* [Avast Antivirus](https://www.avast.com/business/products/antivirus-for-linux) (via socket protocol)
 * [Avira](https://oem.avira.com/en/solutions/anti-malware#SAV) (via SAVAPI)
 * [ClamAV](https://www.clamav.net)
 * F-Prot (End-of-Life as of 31-July-2021)
 * [Kaspersky antivirus](https://www.kaspersky.com/small-to-medium-business-security/linux-mail-server) (from 1.8.3)
 * [Kaspersky Scan Engine](https://www.kaspersky.com/scan-engine) (from 2.0)
-* [Sophos](https://web.archive.org/web/20140810135906/https://www.sophos.com/en-us/medialibrary/PDFs/partners/sophossavdidsna.pdf) (via SAVDI)
-
-
+* [MetaDefender Cloud](https://metadefender.opswat.com/) (hash-based lookups)
+* [Sophos](https://www.sophos.com/) (via SAVDI)
+* [VirusTotal](https://www.virustotal.com/) (hash-based lookups)
 
 ## Configuration
 
-The configuration for an antivirus setup is accomplished by defining rules. If the antivirus reports one or more viruses, the configured symbol (e.g. CLAM_VIRUS) will be set, with the viruses as the description. If set, the reset action will be triggered.
+The configuration for an antivirus setup is accomplished by defining rules. If the antivirus reports one or more viruses, the configured symbol (e.g. `CLAM_VIRUS`) will be set, with the virus name as the description. If set, the configured action will be triggered.
 
-In case of errors during the connection or if the antivirus reports failures, the fail symbol (e.g. CLAM_VIRUS_FAIL) will be set, with the error message as the description. The [force_actions](/modules/force_actions) plugin can be used to perform a `soft reject` if the antivirus has failed to scan the email, such as during a database reloading.
+In case of errors during the connection or if the antivirus reports failures, the fail symbol (e.g. `CLAM_VIRUS_FAIL`) will be set, with the error message as the description. The [force_actions](/modules/force_actions) module can be used to perform a `soft reject` if the antivirus has failed to scan the email, such as during a database reloading.
 
-In addition to the `SYMBOLNAME` and `SYMBOLNAME_FAIL` symbols, there are currently two special symbols indicating that the scanner has reported encrypted parts or parts with Office macros: `SYMBOLNAME_ENCRYPTED` and `SYMBOLNAME_MACRO`
+In addition to the `SYMBOLNAME` and `SYMBOLNAME_FAIL` symbols, there are two special symbols indicating that the scanner has reported encrypted parts or parts with Office macros: `SYMBOLNAME_ENCRYPTED` and `SYMBOLNAME_MACRO`.
 
-For virus, encrypted and macro symbols, patterns can be used to set a dedicated symbol for any virus name or error message. For the fail symbol, the `patterns_fail` option must be used.
+Settings should be added to `/etc/rspamd/local.d/antivirus.conf`.
+
+### Common configuration options
+
+All scanner types support these common options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `type` | string | (required) | Scanner type: `clamav`, `fprot`, `sophos`, `savapi`, `kaspersky`, `kaspersky_se`, `avast`, `virustotal`, `metadefender` |
+| `symbol` | string | (auto) | Symbol to set when virus is found |
+| `symbol_fail` | string | `{SYMBOL}_FAIL` | Symbol to set on scan failure |
+| `symbol_encrypted` | string | `{SYMBOL}_ENCRYPTED` | Symbol to set for encrypted content |
+| `symbol_macro` | string | `{SYMBOL}_MACRO` | Symbol to set for Office macros |
+| `servers` | string | (required) | Server address(es), can be TCP (`host:port`) or Unix socket path |
+| `timeout` | number | (varies) | Connection timeout in seconds |
+| `retransmits` | number | (varies) | Number of retry attempts on failure |
+| `max_size` | number | (none) | Skip scanning for messages larger than this (bytes) |
+| `min_size` | number | (none) | Skip scanning for messages smaller than this (bytes) |
+| `scan_mime_parts` | boolean | `true` | Scan attachments separately instead of whole message |
+| `scan_text_mime` | boolean | `false` | Include text parts when scanning mime parts |
+| `scan_image_mime` | boolean | `false` | Include image parts when scanning mime parts |
+| `log_clean` | boolean | `false` | Log messages when content is clean |
+| `action` | string | (none) | Force this action when virus found (e.g., `reject`) |
+| `message` | string | (varies) | Custom rejection message, supports `${SCANNER}` and `${VIRUS}` variables |
+| `whitelist` | string | (none) | Path to map of IP addresses to skip scanning |
+| `patterns` | table | (none) | Regex patterns to map virus names to custom symbols |
+| `patterns_fail` | table | (none) | Regex patterns to map error messages to custom symbols |
+| `prefix` | string | (auto) | Redis cache key prefix |
+| `cache_expire` | number | 3600 | Redis cache expiration time in seconds |
+| `no_cache` | boolean | `false` | Disable Redis caching |
+| `dynamic_scan` | boolean | `false` | Skip scanning if message already exceeds 2x reject threshold |
+| `text_part_min_words` | number | (none) | Minimum words required in text parts to scan |
+| `show_attachments` | boolean | `false` | Include attachment filename in symbol options |
+| `symbol_type` | string | `normal` | Set to `postfilter` to run after other filters |
+| `score` | number | (none) | Score to assign to the symbol |
+| `description` | string | (none) | Description for the symbol |
+| `group` | string | `antivirus` | Symbol group |
+
+### Pattern matching
+
+For virus, encrypted, and macro symbols, patterns can be used to set a dedicated symbol based on the virus name or error message. For failure symbols, use `patterns_fail`:
 
 ~~~hcl
-...
-  patterns {
-    # symbol_name = "pattern";
-    JUST_EICAR = '^Eicar-Test-Signature$';
-  }
-  patterns_fail { # 1.8.4+
-    # symbol_name = "pattern";
-    CLAM_LIMITS_EXCEEDED = '^Heuristics\.Limits\.Exceeded$';
-  }
-...
+patterns {
+  # symbol_name = "regex_pattern";
+  JUST_EICAR = '^Eicar-Test-Signature$';
+  SANE_MAL = 'Sanesecurity\.Malware\.*';
+  CLAM_UNOFFICIAL = 'UNOFFICIAL$';
+}
+patterns_fail {
+  # symbol_name = "regex_pattern";
+  CLAM_LIMITS_EXCEEDED = '^Heuristics\.Limits\.Exceeded$';
+}
 ~~~
 
-From version 3.5, you are able to use two more types of mime part filters:
+### MIME part filtering
+
+From version 3.5, you can filter which mime parts are sent to the scanner using regex patterns or file extensions:
 
 ~~~hcl
-...
-  mime_parts_filter_regex {
-    FILE1 = "^invoice\.xls$"
-    DOC1 = "application\/msword";
-    DOC2 = "application\/vnd\.ms-word.*";
-    GEN2 = "application\/vnd\.openxmlformats-officedocument.*";
-  }
-  # Mime-Part filename extension matching (no regex)
-  mime_parts_filter_ext {
-    doc = "doc";
-    docx = "docx";
-  }
-...
+# Match content-type or filename with regex
+mime_parts_filter_regex {
+  FILE1 = "^invoice\.xls$";
+  DOC1 = "application\/msword";
+  DOC2 = "application\/vnd\.ms-word.*";
+  GEN2 = "application\/vnd\.openxmlformats-officedocument.*";
+}
+# Match filename extension (no regex)
+mime_parts_filter_ext {
+  doc = "doc";
+  docx = "docx";
+}
 ~~~
 
-The `mime_parts_filter_regex` option matches the content-type detected by Rspamd, or a mime part header, or the declared filename of an attachment. The latter option also works for files within an archive. The `mime_parts_filter_ext` option matches the extension of the declared filename or an archive's file list.
+The `mime_parts_filter_regex` option matches the content-type detected by Rspamd, mime part headers, or the declared filename of an attachment. This also works for files within archives. The `mime_parts_filter_ext` option matches the extension of the declared filename or files within archives.
 
-By default, the complete email will be sent to the antivirus system. This behavior can be changed by setting the `scan_mime_parts`option to true, which will send all detected attachments as separate mime parts. The options `scan_text_mime` or `scan_image_mime` can also be set to true if you want text mimes and images sent to the AV scanner.
+When any filter is defined, only matching parts are scanned. Without filters, all attachments are scanned.
 
-By default, if [Redis](/configuration/redis) is configured globally and the `antivirus` option is not explicitly disabled in the Redis configuration, the results will be cached in Redis according to message checksums.
+### Redis caching
 
-Settings should be added to `/etc/rspamd/local.d/antivirus.conf` file:
+By default, if [Redis](/configuration/redis) is configured globally and the `antivirus` option is not explicitly disabled in the Redis configuration, scan results are cached using message checksums. Configure `cache_expire` to control the TTL.
+
+## ClamAV
+
+ClamAV is the most commonly used open-source antivirus scanner. It communicates via the `INSTREAM` protocol.
+
+**Scanner-specific defaults:**
+- `default_port`: 3310
+- `timeout`: 5.0 seconds
+- `retransmits`: 2
+- `cache_expire`: 3600 seconds
 
 ~~~hcl
 # local.d/antivirus.conf
 
-# multiple scanners could be checked, for each we create a configuration block with an arbitrary name
 clamav {
-  # If set force this action if any virus is found (default unset: no action is forced)
+  # If set, force this action when any virus is found
   # action = "reject";
   # message = '${SCANNER}: virus found: "${VIRUS}"';
-  # Scan mime_parts separately - otherwise the complete mail will be transferred to AV Scanner
-  #attachments_only = true; # Before 1.8.1
-  #scan_mime_parts = true; # After 1.8.1
-  # Scanning Text is suitable for some av scanner databases (e.g. Sanesecurity)
-  #scan_text_mime = false; # 1.8.1 +
-  #scan_image_mime = false; # 1.8.1 +
-  # If `max_size` is set, messages > n bytes in size are not scanned
-  #max_size = 20000000;
-  # symbol to add (add it to metric if you want non-zero weight)
+  
+  # Scan attachments separately (recommended)
+  scan_mime_parts = true;
+  
+  # Include text/image parts (useful for Sanesecurity databases)
+  # scan_text_mime = false;
+  # scan_image_mime = false;
+  
+  # Skip messages larger than this size
+  # max_size = 20000000;
+  
   symbol = "CLAM_VIRUS";
-  # type of scanner: "clamav", "fprot", "sophos" or "savapi"
   type = "clamav";
-  # If set true, log message is emitted for clean messages
-  #log_clean = false;
-  # Prefix used for caching in Redis: scanner-specific defaults are used. If Redis is enabled and
-  # multiple scanners of the same type are present, it is important to set prefix to something unique.
-  #prefix = "rs_cl_";
-  # For "savapi" you must also specify the following variable
-  #product_id = 12345;
-  # servers to query (if port is unspecified, scanner-specific default is used)
-  # can be specified multiple times to pool servers
-  # can be set to a path to a unix socket
+  
+  # Log clean results
+  # log_clean = false;
+  
+  # Server address (TCP or Unix socket)
   servers = "127.0.0.1:3310";
-  # if `patterns` is specified virus name will be matched against provided regexes and the related
-  # symbol will be yielded if a match is found. If no match is found, default symbol is yielded.
+  
+  # Pattern-based symbol mapping
   patterns {
-    # symbol_name = "pattern";
     JUST_EICAR = '^Eicar-Test-Signature$';
   }
-  # In version 1.7.0+ patterns could be extended
-  #patterns = {SANE_MAL = 'Sanesecurity\.Malware\.*', CLAM_UNOFFICIAL = 'UNOFFICIAL$'};
-  # `whitelist` points to a map of signature names. Hits on these signatures are ignored.
-  whitelist = "/etc/rspamd/antivirus.wl";
+  
+  # Whitelist IPs that should not be scanned
+  # whitelist = "/etc/rspamd/antivirus.wl";
+  
+  # Replace this exact string with EICAR for testing
+  # eicar_fake_pattern = 'testpatterneicar';
 }
 ~~~
 
-## Sophos SAVDI specific details
+## Sophos SAVDI
 
-Sophos SAVDI is a daemon that extends Sophos Anti-Virus for Linux to be reachable via TCP sockets using the generic ICAP or the Sophos-specific Sophie and SSSP protocols. Both Sophos Anti-Virus for Linux and the Sophos SAVDI daemon need to be installed.
+Sophos SAVDI is a daemon that extends Sophos Anti-Virus for Linux to be reachable via TCP sockets using the SSSP protocol. Both Sophos Anti-Virus for Linux and the Sophos SAVDI daemon must be installed.
 
-Rspamd uses the SSSP protocol to communicate with SAVDI. A sample SAVDI configuration can be found at [https://gist.github.com/c-rosenberg/671b0a5d8b1b5a937e3e161f8515c666](https://gist.github.com/c-rosenberg/671b0a5d8b1b5a937e3e161f8515c666)
+**Scanner-specific defaults:**
+- `default_port`: 4010
+- `timeout`: 15.0 seconds
+- `retransmits`: 2
 
-Note: Since version 1.9.0, SAVDI errors will be reported in the fail symbol (e.g. SOPHOS_VIRUS_FAIL), making the following configuration obsolete.
-
-From version 1.7.2 up to 1.8.3, there are two special configuration parameters for handling SAVDI warnings/error messages in the `sophos` section: `savdi_report_encrypted` and `savdi_report_oversized`. When enabled, pseudo virus names (SAVDI_FILE_OVERSIZED, SAVDI_FILE_ENCRYPTED) will be set in case Sophos reports an encrypted file or if the file is bigger than `maxscandata` in the `scanprotocol` section of the SAVDI configuration file.
-
-If you don't want to handle those pseudo virus names like everything else you could use patterns to set
-a different symbol and maybe set a score or use the symbol in `force_actions`.
+A sample SAVDI configuration is available at [this gist](https://gist.github.com/c-rosenberg/671b0a5d8b1b5a937e3e161f8515c666).
 
 ~~~hcl
 # local.d/antivirus.conf
 
 sophos {
-  ...
-  savdi_report_encrypted = true;
-  savdi_report_encrypted = true;
-
-  patterns {
-    # symbol_name = "pattern";
-    SAVDI_FILE_ENCRYPTED = "^SAVDI_FILE_ENCRYPTED$";
-    SAVDI_FILE_OVERSIZED = "^SAVDI_FILE_OVERSIZED$";
-  }
-  ...
+  symbol = "SOPHOS_VIRUS";
+  type = "sophos";
+  servers = "127.0.0.1:4010";
+  scan_mime_parts = true;
 }
 ~~~
 
-## SAVAPI specific details
+SAVDI automatically reports encrypted files (`FAIL 0212`) and oversized files (`REJ 4`) which Rspamd handles appropriately.
 
-The default configuration for SAVAPI uses a listening unix socket. However, it is recommended to change this to a TCP socket for better security and reliability. The `ListenAddress` option in savapi.conf provides examples on how to do this. By default, the module expects the socket to be located at 127.0.0.1:4444, but this can be changed by setting it in the `servers` variable.
+## Avira SAVAPI
 
-Additionally, it is important to set the `product_id` to match the id for your HBEDV.key file. Failure to do so will result in a log message indicating that the given id was invalid.
+SAVAPI is Avira's scanning interface. By default, it uses a Unix socket, but TCP is recommended for better reliability. Set `ListenAddress` in savapi.conf to configure TCP mode.
 
-## Kaspersky specific
+**Scanner-specific defaults:**
+- `default_port`: 4444
+- `timeout`: 15.0 seconds
 
-In terms of Kaspersky specific configurations, it is possible to use the `clamav` socket for data scanning. However, it should be noted that it is a unix socket and can only be used for local scans. It is also important that Rspamd should be able to write into Kaspersky Unix socket. For example, you can add Rspamd user (`_rspamd` on Linux most likely) into `klusers` group: `usermod -G klusers _rspamd` in Linux. Rspamd will also write data into some intermediate files that are normally placed in `/tmp` folder.
+**Important:** You must set `product_id` to match your HBEDV.key file ID.
 
 ~~~hcl
 # local.d/antivirus.conf
+
+savapi {
+  symbol = "SAVAPI_VIRUS";
+  type = "savapi";
+  servers = "127.0.0.1:4444";
+  product_id = 12345;  # Required - must match your license key
+  scan_mime_parts = true;
+}
+~~~
+
+## Kaspersky
+
+Kaspersky Anti-Virus for Linux Mail Server uses a Unix socket for local scans. Rspamd must have write access to the socket (add the rspamd user to `klusers` group).
+
+**Important:** Rspamd writes data to temporary files in `tmpdir` (default `/tmp`). This directory must be readable by the `klusers` user/group.
+
+~~~hcl
+# local.d/antivirus.conf
+
 kaspersky {
   symbol = "KAS_VIRUS";
+  type = "kaspersky";
   servers = "/var/run/klms/rds_av";
   max_size = 2048000;
-  scan_mime_parts = true; # Scan just attachments
-  tmpdir = "/tmp"; # Must be writable by `_rspamd` user and readable by `klusers` user/group
+  scan_mime_parts = true;
+  tmpdir = "/tmp";  # Must be accessible to both rspamd and klusers
 }
 ~~~
 
-## Kaspersky Scan Engine details
+To grant access:
+```bash
+usermod -G klusers _rspamd
+```
 
-The engine utilizes the HTTP REST API version 1.0, as outlined in the Kaspersky [documentation](https://help.kaspersky.com/ScanEngine/1.0/en-US/181038.htm). Rspamd can operate in both file and TCP stream modes. The file mode may be useful if you have a fast `tmpfs` in-memory storage and wish to reduce the amount of data transferred over a socket for the local machine. However, this mode is not recommended for any type of real storage, including SSDs. The following settings are available for this engine:
+## Kaspersky Scan Engine
+
+Kaspersky Scan Engine uses HTTP REST API version 1.0 ([documentation](https://help.kaspersky.com/ScanEngine/1.0/en-US/181038.htm)). It supports both TCP stream and file modes.
+
+**Scanner-specific options:**
+- `use_files`: Set to `true` to use file mode (only recommended with fast tmpfs storage)
+- `use_https`: Set to `true` to enable SSL
 
 ~~~hcl
 # local.d/antivirus.conf
+
 kaspersky_se {
   symbol = "KAS_SE_VIRUS";
-  servers = "127.0.0.1:1234"; # Mandatory, dos not supports Unix sockets
+  type = "kaspersky_se";
+  servers = "127.0.0.1:1234";  # Required, Unix sockets not supported
   max_size = 2048000;
-  timeout = 5.0; # Allow 5 seconds for scan
-  scan_mime_parts = true; # Just attachments
-  use_files = false; # Or true if you want this mode
-  use_https = false; # Enable if you like to use SSL
+  timeout = 5.0;
+  scan_mime_parts = true;
+  use_files = false;  # Use TCP stream mode (recommended)
+  use_https = false;  # Enable for SSL
 }
 ~~~
 
-## Avast Antivirus Rest API details
+## Avast
 
-You need to install the Avast-rest package in addition to the Avast antivirus package. It is also recommended to adjust the default settings in /etc/avast/rest.conf. Rspamd can operate in both file and TCP stream modes. File mode can be useful if you have a fast `tmpfs` that relies on memory, but this is not recommended for any type of real storage, even SSD.
+Avast for Linux uses a socket-based protocol. The scanner saves content to temporary files before scanning.
 
-Warnings such as corrupt file or possible zip bomb are only logged. However, you can set `warnings_as_threat = true` if you want Rspamd to treat these warnings as pseudo viruses. It is recommended to use patterns to avoid false positives.
-
-With the parameter option, you can set any option for the rest-api from Rspamd.
-
-Here are possible settings for this engine:
+**Scanner-specific defaults:**
+- `timeout`: 4.0 seconds
+- `retransmits`: 1
+- `tmpdir`: `/tmp`
 
 ~~~hcl
 # local.d/antivirus.conf
+
 avast {
-
   symbol = "AVAST_VIRUS";
-  servers = "127.0.0.1:8080";
-
-  scan_mime_parts = true; # (Default) Just attachments
-  use_files = false; # (Default) Or true if you need the file mode (not recommend)
-  use_https = false; # (Default) Enable if you like to use SSL
-
-  warnings_as_threat = false; # (Default)
-
-  # https://repo.avcdn.net/linux-av/doc/avast-techdoc.pdf
-  parameter = {
-    archives = true, # (Default) 
-    # email = false,
-    # full = false,
-    # pup = false,
-    # heuristics = 40,
-    # detections = false,
-  
-  }
+  type = "avast";
+  servers = "/var/run/avast/scan.sock";  # Unix socket path
+  scan_mime_parts = true;
 }
 ~~~
 
-## Generic Anti-Virus support via ICAP protocol
+## VirusTotal
 
-The ICAP protocol is implemented in [external_services](/modules/external_services#icap-protocol-specific-details).
+VirusTotal integration performs hash-based lookups against their database. **An API key is required.**
 
-Currently these products are tested with Rspamd (please report others):
+**Scanner-specific options:**
+- `apikey`: Your VirusTotal API key (required)
+- `url`: API endpoint (default: `https://www.virustotal.com/vtapi/v2/file`)
+- `minimum_engines`: Minimum detections required to trigger (default: 3)
+- `low_category`: Threshold for low threat category (default: 5)
+- `medium_category`: Threshold for medium threat category (default: 10)
+- `symbols`: Category-based symbol configuration
+
+This scanner uses hash lookups (MD5), so it only detects known threats. It produces category-based symbols instead of a single virus symbol:
+
+- `VIRUSTOTAL_CLEAN`: No detections (negative score)
+- `VIRUSTOTAL_LOW`: Few detections (minimum_engines to low_category-1)
+- `VIRUSTOTAL_MEDIUM`: Moderate detections (low_category to medium_category-1)
+- `VIRUSTOTAL_HIGH`: Many detections (medium_category and above)
+
+~~~hcl
+# local.d/antivirus.conf
+
+virustotal {
+  type = "virustotal";
+  apikey = "your-api-key-here";  # Required
+  
+  scan_mime_parts = true;
+  
+  # Minimum detections to consider as threat
+  minimum_engines = 3;
+  
+  # Category thresholds
+  low_category = 5;
+  medium_category = 10;
+  
+  # Custom symbols and scores
+  symbols = {
+    clean = {
+      symbol = "VIRUSTOTAL_CLEAN";
+      score = -0.5;
+      description = "VirusTotal: attachment is clean";
+    };
+    low = {
+      symbol = "VIRUSTOTAL_LOW";
+      score = 2.0;
+      description = "VirusTotal: low threat level";
+    };
+    medium = {
+      symbol = "VIRUSTOTAL_MEDIUM";
+      score = 5.0;
+      description = "VirusTotal: medium threat level";
+    };
+    high = {
+      symbol = "VIRUSTOTAL_HIGH";
+      score = 8.0;
+      description = "VirusTotal: high threat level";
+    };
+  };
+}
+~~~
+
+**Note:** VirusTotal has rate limits on their API. Consider `cache_expire` settings to minimize API calls.
+
+## MetaDefender Cloud
+
+MetaDefender Cloud by OPSWAT performs hash-based lookups (SHA256) against multiple antivirus engines. **An API key is required.**
+
+**Scanner-specific options:**
+- `apikey`: Your MetaDefender API key (required)
+- `url`: API endpoint (default: `https://api.metadefender.com/v4/hash`)
+- `minimum_engines`: Minimum detections required to trigger (default: 3)
+- `low_category`: Threshold for low threat category (default: 5)
+- `medium_category`: Threshold for medium threat category (default: 10)
+- `symbols`: Category-based symbol configuration
+
+Like VirusTotal, this scanner uses hash lookups and produces category-based symbols:
+
+- `METADEFENDER_CLEAN`: No detections
+- `METADEFENDER_LOW`: Few detections
+- `METADEFENDER_MEDIUM`: Moderate detections
+- `METADEFENDER_HIGH`: Many detections
+
+~~~hcl
+# local.d/antivirus.conf
+
+metadefender {
+  type = "metadefender";
+  apikey = "your-api-key-here";  # Required
+  
+  scan_mime_parts = true;
+  
+  minimum_engines = 3;
+  low_category = 5;
+  medium_category = 10;
+}
+~~~
+
+## ICAP Protocol
+
+Generic antivirus support via ICAP protocol is available through the [external_services](/modules/external_services#icap-protocol-specific-details) module.
+
+The following products have been tested with Rspamd via ICAP:
 
 * Checkpoint Sandblast
 * ClamAV (using c-icap server and squidclamav)
@@ -229,6 +381,6 @@ Currently these products are tested with Rspamd (please report others):
 * McAfee Web Gateway 9/10/11
 * Metadefender ICAP
 * Sophos (via SAVDI)
-* Symantec Protection Engine for Cloud Services (Rspamd <3.2, >=3.2 untested)
+* Symantec Protection Engine for Cloud Services
 * Trend Micro InterScan Web Security Virtual Appliance (IWSVA)
 * Trend Micro Web Gateway


### PR DESCRIPTION
## Summary

This PR updates the antivirus module documentation to match the current codebase.

### Key changes:

- **Added new scanners**: VirusTotal and MetaDefender Cloud are now documented
- **Added comprehensive configuration reference table** with all common options including previously undocumented options: `min_size`, `text_part_min_words`, `dynamic_scan`, `retransmits`, `no_cache`, `show_attachments`, `symbol_type`
- **Fixed Avast documentation**: Corrected description (socket-based protocol, not REST API)
- **Removed deprecated Sophos options**: `savdi_report_encrypted` and `savdi_report_oversized` no longer exist in code
- **Improved structure**: Reorganized into clearer sections with scanner-specific defaults
- **Fixed whitelist description**: Now correctly describes it as IP address map
- **Added pattern matching documentation** with more examples
- **Updated scanner-specific sections** with accurate default values from code