### PR TITLE
Update documentation for mid module

### DIFF
--- a/docs/modules/mid.md
+++ b/docs/modules/mid.md
@@ -9,17 +9,30 @@ The purpose of the MID module is to suppress the `INVALID_MSGID` (malformed Mess
 
 ## Configuration
 
-The default configuration of this module is shown below:
+The module requires a `source` parameter pointing to a map file.
+
+### Configuration options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `source` | required | Map of domains and optional Message-ID patterns |
+| `symbol_known_mid` | `KNOWN_MID` | Symbol for known Message-ID pattern match |
+| `symbol_known_no_mid` | `KNOWN_NO_MID` | Symbol for known missing Message-ID |
+| `symbol_invalid_msgid` | `INVALID_MSGID` | Symbol to suppress for invalid Message-ID |
+| `symbol_missing_mid` | `MISSING_MID` | Symbol to suppress for missing Message-ID |
+| `symbol_dkim_allow` | `R_DKIM_ALLOW` | DKIM allow symbol to check |
+| `csymbol_invalid_msgid_allowed` | `INVALID_MSGID_ALLOWED` | Composite symbol for allowed invalid Message-ID |
+| `csymbol_missing_mid_allowed` | `MISSING_MID_ALLOWED` | Composite symbol for allowed missing Message-ID |
+
+### Example configuration
 
 ~~~hcl
 mid = {
-  url = [
-    "${CONFDIR}/mid.inc",
-  ]; 
+  source = "${CONFDIR}/mid.inc";
 }
 ~~~
 
-The `url` setting points to a list of maps to check DKIM signatures (& optionally message-ids) against, formatted as follows:
+The `source` setting points to a map to check DKIM signatures (& optionally message-ids) against, formatted as follows:
 
 ~~~
 example.com /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}-0$/


### PR DESCRIPTION
## Summary

This PR adds configuration options table to the mid module documentation and fixes the parameter name.

### Added:
- Configuration options table with all customizable symbols
- `symbol_known_mid`, `symbol_known_no_mid`
- `symbol_invalid_msgid`, `symbol_missing_mid`
- `symbol_dkim_allow`
- `csymbol_invalid_msgid_allowed`, `csymbol_missing_mid_allowed`

### Fixed:
- Changed `url` to `source` to match actual code parameter name