### PR TITLE
Update documentation for once_received module

### DIFF
--- a/docs/modules/once_received.md
+++ b/docs/modules/once_received.md
@@ -10,6 +10,19 @@ This module is intended to do simple checks for mail with one `Received` header.
 
 Configuring this module is quite straightforward: you simply need to define a `symbol` for generic emails with only one received header, specify a `symbol_strict` for emails that exhibit negative patterns or have unresolved hostnames, and include **good** and **bad** patterns, which can utilise [lua patterns](http://lua-users.org/wiki/PatternsTutorial). Use `good_host` lines to exclude certain hosts from this module, and `bad_host` lines to identify specific negative patterns. Additionally, you can create a `whitelist` to define a list of networks for which the `once_received` checks should be excluded.
 
+### Configuration options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `symbol` | `ONCE_RECEIVED` | Symbol for messages with only one received header |
+| `symbol_strict` | nil | Symbol for messages matching bad patterns or unresolved hostnames |
+| `symbol_mx` | `DIRECT_TO_MX` | Symbol for direct MUA to MX connections (detected via User-Agent/X-Mailer) |
+| `good_host` | - | Lua pattern for hostnames to exclude from checks |
+| `bad_host` | - | Lua pattern for hostnames that trigger strict symbol |
+| `whitelist` | nil | Map of IP addresses/networks to exclude from checks |
+| `check_local` | false | Apply checks to messages from local networks |
+| `check_authed` | false | Apply checks to messages from authenticated users |
+
 ## Example
 
 ~~~hcl


### PR DESCRIPTION
## Summary

This PR adds a configuration options table to the once_received module documentation.

### Added options:

- `symbol` - main symbol for single received header
- `symbol_strict` - symbol for bad patterns/unresolved hostnames
- `symbol_mx` - symbol for direct MUA to MX connections
- `good_host` - patterns to exclude
- `bad_host` - patterns that trigger strict symbol
- `whitelist` - IP/network exclusion map
- `check_local` - apply to local networks
- `check_authed` - apply to authenticated users