### PR TITLE
Use standard custom rule path in examples

### DIFF
--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -177,7 +177,7 @@ See [Statistic configuration](/configuration/statistic), [Neural module](/module
 
 Example custom rule:
 ```lua
--- /etc/rspamd/local.d/custom_rules.lua
+-- /etc/rspamd/rspamd.local.lua
 rspamd_config.SUSPICIOUS_ATTACHMENT = {
   callback = function(task)
     local parts = task:get_parts()

--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -177,7 +177,8 @@ See [Statistic configuration](/configuration/statistic), [Neural module](/module
 
 Example custom rule:
 ```lua
--- /etc/rspamd/rspamd.local.lua
+-- /etc/rspamd/lua.local.d/custom_rule.lua
+-- `custom_rule` basename is arbitrary
 rspamd_config.SUSPICIOUS_ATTACHMENT = {
   callback = function(task)
     local parts = task:get_parts()

--- a/docs/configuration/selectors.md
+++ b/docs/configuration/selectors.md
@@ -361,7 +361,7 @@ In general, you need not be overly concerned about type safety unless you encoun
 
 ## Own selectors
 
-You have the option to incorporate your custom extractors and processing functions. However, it's crucial to implement this setup before utilizing these selectors in any other context. For instance, the execution of `rspamd.local.lua` precedes the initialization of plugins, making it a secure location to register your functions. Here is a small example about how to register your own extractors and processors.
+You have the option to incorporate your custom extractors and processing functions. However, it's crucial to implement this setup before utilizing these selectors in any other context. For instance, the execution of scripts located inside `lua.local.d/` precedes the initialization of plugins, making it a secure location to register your functions. Here is a small example about how to register your own extractors and processors.
 
 ~~~lua
 local lua_selectors = require "lua_selectors" -- Import module
@@ -398,7 +398,7 @@ You can use these functions in your selectors subsequently.
 
 You can also leverage selectors with Rspamd's [regexp module](/modules/regexp). This approach allows you to utilize the data extracted and processed by the selector framework to match it against various regular expressions.
 
-To start, you'll need to register a selector in the regexp module. You can achieve this by adding the following code to your `rspamd.local.lua` file:
+To start, you'll need to register a selector in the regexp module. You can achieve this by adding the following code to a Lua script inside `lua.local.d/` directory:
 
 ~~~lua
 rspamd_config:register_re_selector('test', 'user.lower;header(Subject).lower', ' ')

--- a/docs/developers/examples.md
+++ b/docs/developers/examples.md
@@ -8,7 +8,7 @@ title: Lua rules examples
 
 Here is the collection of the useful Lua rules snippets that are not the official rules but could be used to filter specific spam.
 
-To enable these snippets, you can place them to the `rspamd.local.lua` file. Typically it will be `/etc/rspamd/rspamd.local.lua` file for the Linux distros (or `/usr/local/etc/rspamd/rspamd.local.lua` for others).
+To enable these snippets, you can place them to any `.lua` file located under the `lua.local.d` directory. Typically the path will be `/etc/rspamd/lua.local.d/` for the Linux distros (or `/usr/local/etc/rspamd/lua.local.d/` for others).
 
 
 

--- a/docs/developers/writing_rules.md
+++ b/docs/developers/writing_rules.md
@@ -47,7 +47,7 @@ rspamd_config:register_symbol({
 ### Your first symbol
 
 ```lua
--- /etc/rspamd/local.d/custom_rules.lua
+-- /etc/rspamd/rspamd.local.lua
 local function always_fires(task)
   return true
 end
@@ -360,5 +360,3 @@ config['regexp']['SYMBOL'] = { callback = function(task) ... end }
 | Post-filters | After normal filters and composites |
 | Composites (pass 2) | Combine results including postfilters |
 | Idempotent filters | Must not change result |
-
-

--- a/docs/developers/writing_rules.md
+++ b/docs/developers/writing_rules.md
@@ -47,7 +47,8 @@ rspamd_config:register_symbol({
 ### Your first symbol
 
 ```lua
--- /etc/rspamd/rspamd.local.lua
+-- /etc/rspamd/lua.local.d/custom_rule.lua
+-- `custom_rule` basename is arbitrary
 local function always_fires(task)
   return true
 end

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -266,7 +266,7 @@ enabled = false;
 
 ### How do I disable a specific rule?
 
-Add a condition in `/etc/rspamd/rspamd.local.lua`:
+Create a `.lua` file in `/etc/rspamd/lua.local.d/` and add a condition:
 
 ```lua
 rspamd_config:add_condition('SOME_SYMBOL', function(task) return false end)

--- a/docs/modules/external_relay.md
+++ b/docs/modules/external_relay.md
@@ -19,7 +19,7 @@ Different strategies for identifying mail to tamper with and the point of hand-o
 
 If the strategies are too broad to be used in your setup you might limit them using `rspamd_config:add_condition()`, for example:
 ~~~lua
-# /etc/rspamd/rspamd.local.lua
+-- /etc/rspamd/lua.local.d/external_relay.lua
 -- add some condition for the symbol called EXTERNAL_RELAY_COUNT
 rspamd_config:add_condition('EXTERNAL_RELAY_COUNT', function(task)
   -- only apply this rule if authenticated user is postmaster@example.net

--- a/docs/tutorials/clickhouse_analytics.md
+++ b/docs/tutorials/clickhouse_analytics.md
@@ -74,8 +74,8 @@ extra_columns = {
   "from_domain" = "from:domain";
   "mime_type" = "header('Content-Type')";
   "user_agent" = "header('User-Agent')";
-  
-  # Custom selectors (must be registered in rspamd.local.lua first!)
+
+  # Custom selectors (must be registered in lua.local.d/ first!)
   "attachment_count" = "attachment_count()";
   "has_executable" = "has_dangerous_attachment()";
   "attachment_extensions" = "attachment_types()";
@@ -229,10 +229,11 @@ Here's how to integrate custom selectors with ClickHouse from start to finish:
 
 #### Step 1: Register Custom Selectors
 
-First, register your custom selectors in `/etc/rspamd/rspamd.local.lua`:
+First, register your custom selectors in `/etc/rspamd/lua.local.d/`:
 
 ```lua
--- /etc/rspamd/rspamd.local.lua
+-- /etc/rspamd/lua.local.d/custom_selectors.lua
+-- `custom_selectors` is arbitrary
 
 local lua_selectors = require "lua_selectors"
 
@@ -560,7 +561,7 @@ ORDER BY Messages DESC;
 ```
 
 **Key Points:**
-- Selector names in `rspamd.local.lua` must match those used in `clickhouse.conf`
+- Selector names in `lua.local.d/custom_selectors.lua` must match those used in `clickhouse.conf`
 - All custom selectors return string values to ClickHouse
 - Restart Rspamd after adding new selectors
 - Custom columns appear automatically in the ClickHouse table


### PR DESCRIPTION
Hey there!

I wrote my first rules using the tutorial and I found the comment hinting `/etc/rspamd/local.d/custom_rule.lua` a bit misleading.

I wonder if it is an old way of autoloading rules? Or maybe the file is meant to be manually included in a plugin?

But I think most readers will first try simple rules and expect them to be loaded.

If you agree, here's a mini-PR. Have a nice day! 