### PR TITLE
Fix actions.conf syntax

### DIFF
--- a/docs/getting-started/understanding-rspamd.md
+++ b/docs/getting-started/understanding-rspamd.md
@@ -444,11 +444,9 @@ Rspamd uses a **layered configuration system** with clear precedence:
 **File**: `/etc/rspamd/local.d/actions.conf`
 
 ```nginx
-actions {
-    reject = 15.0;          # Refuse message
-    add_header = 6.0;       # Mark as spam
-    greylist = 4.0;         # Temporary delay
-}
+reject = 15.0;          # Refuse message
+add_header = 6.0;       # Mark as spam
+greylist = 4.0;         # Temporary delay
 ```
 
 **When to adjust:**


### PR DESCRIPTION
Currently, docs.rspamd.com recommends invalid syntax for your config files. This PR fixes this.


If I put this in my `/etc/rspamd/local.d/actions.conf`:
```
actions = {
    reject = 15;          # Refuse message
    add_header = 6;       # Mark as spam
    greylist = 4;         # Temporary delay
}
```

configtest complains:
```
# rspamadm configtest
unknown element in actions section: actions
nested section: actions { actions { ... } }, it is likely a configuration error
action actions has no threshold being set and it is not a no threshold action
rcl parse error: invalid action definition for: 'actions'
syntax BAD
```

But if I put this in my `/etc/rspamd/local.d/actions.conf`
```
reject = 15;          # Refuse message
add_header = 6;       # Mark as spam
greylist = 4;         # Temporary delay
```
everything seems to work
```
# rspamadm configtest
syntax OK
```