### PR TITLE
fix: incorrect command for configdump

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -122,7 +122,7 @@ Different environments have different needs. Find the guide that matches your si
 ### Built-in Help
 ```bash
 # Check current configuration
-rspamc configdump
+rspamadm configdump
 
 # Validate configuration files
 rspamd -t

--- a/docs/getting-started/first-setup.md
+++ b/docs/getting-started/first-setup.md
@@ -264,7 +264,7 @@ sudo setsebool -P antivirus_can_scan_system 1
 If messages have no `X-Spam-*` headers:
 
 ```bash
- rspamadm configdump milter_headers
+rspamadm configdump milter_headers
 rspamc stat  # Check messages scanned
 ```
 

--- a/docs/guides/configuration/fundamentals.md
+++ b/docs/guides/configuration/fundamentals.md
@@ -438,10 +438,10 @@ sudo rspamadm configtest -v
 
 ```bash
 # View configuration dump
-rspamc configdump
+rspamadm configdump
 
 # Check specific symbols and scores
-rspamc configdump | grep -A5 -B5 "symbol_name"
+rspamadm configdump | grep -A5 -B5 "symbol_name"
 
 # Monitor real-time changes
 tail -f /var/log/rspamd/rspamd.log

--- a/docs/guides/configuration/index.md
+++ b/docs/guides/configuration/index.md
@@ -122,7 +122,7 @@ Different environments have different needs. Find the guide that matches your si
 ### Built-in Help
 ```bash
 # Check current configuration
-rspamc configdump
+rspamadm configdump
 
 # Validate configuration files
 rspamd -t


### PR DESCRIPTION
The docs contain incorrect `rspamc configdump` instructions, as mentioned in #92 

This was partially fixed in #102

This PR replaces all occurrences found with `find . -type f -exec sed -i 's/rspamc configdump/rspamadm configdump/g' {} +`