### PR TITLE
Update settings_guide.md: corrected typo

### DIFF
--- a/docs/tutorials/settings_guide.md
+++ b/docs/tutorials/settings_guide.md
@@ -332,7 +332,7 @@ trusted_relays {
 2. **Verify setting application**:
    ```bash
    # Test with specific message
-   rspamc -F sender@domain.com -r recipient@company.com < test.eml
+   rspamc --from sender@domain.com --rcpt recipient@company.com < test.eml
    
    # Check which settings applied
    grep "applied.*setting" /var/log/rspamd/rspamd.log

--- a/docs/tutorials/settings_guide.md
+++ b/docs/tutorials/settings_guide.md
@@ -332,7 +332,7 @@ trusted_relays {
 2. **Verify setting application**:
    ```bash
    # Test with specific message
-   rspamc -f sender@domain.com -r recipient@company.com < test.eml
+   rspamc -F sender@domain.com -r recipient@company.com < test.eml
    
    # Check which settings applied
    grep "applied.*setting" /var/log/rspamd/rspamd.log


### PR DESCRIPTION
The test refers to `rspamc -f`. I believe it should be `rspamc -F` instead, which is for specifying the "SMTP FROM address" to use for testing, according to the [man page](https://man.archlinux.org/man/rspamc.1.en).