### PR TITLE
Clarify task_timeout documentation

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -107,7 +107,7 @@ control_socket = "$DBDIR/rspamd.sock mode=0600";
 |`ssl_ca_path`| path to ssl CA file
 |`ssl_ciphers`| list of ssl ciphers (e.g. HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4)
 |`stats_file`| path to stats file
-|`task_timeout`| maximum time for checking a message
+|`task_timeout`| maximum time for processing a single message; tasks exceeding this limit are aborted. At startup, Rspamd may log a warning if individual symbol timeouts suggest that the theoretical maximum processing time exceeds `task_timeout` — this is informational and does not necessarily require any action
 |`temp_dir`| a directory for temporary files (can also be set via the environment variable `TMPDIR`).
 |`tld`| path to the TLD file for urls detector
 |`trusted_keys`| list of trusted public keys used for signatures in base32 encoding

--- a/docs/workers/normal.md
+++ b/docs/workers/normal.md
@@ -11,7 +11,7 @@ Rspamd normal worker is intended to scan messages for spam. It has the following
 | `count` | 4 | Number of normal worker processes to run |
 | `mime` | true | Set to `false` if you want to scan non-MIME messages (e.g. forum comments or SMS) |
 | `timeout` | 60s | Protocol I/O timeout |
-| `task_timeout` | 8s | Maximum time to process a single task |
+| `task_timeout` | 8s | Maximum time to process a single task. See [task_timeout](/configuration/options#task_timeout) |
 | `max_tasks` | 0 | Maximum count of parallel tasks processed by a single worker (0 = no limit) |
 | `keypair` | - | Encryption keypair for secure communications |
 | `encrypted_only` | false | Allow only encrypted connections |


### PR DESCRIPTION
Explain that the startup warning about symbol timeouts exceeding task_timeout is informational and does not require action by default.

Ref rspamd/rspamd#6092