### PR TITLE
Update integration.md

### DIFF
--- a/docs/tutorials/integration.md
+++ b/docs/tutorials/integration.md
@@ -282,10 +282,10 @@ acl_check_spam:
   warn
     set acl_m_report     = ${sg{$spam_report}{\\v\\s+}{\\n}}
     set acl_m_milter_add = ${sg{\
-      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Add: ).*(\\n|$)}{}}}\
+      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Add: ).*(\\n|\$)}{}}}\
       {(?m)^X-Milter-Add: ([^\\[:\\n]+)(?:\\[\\d+\\])?: }{$1: }}
     set acl_m_milter_del = ${sg{\
-      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Del: ).*(\\n|$)}{}}}\
+      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Del: ).*(\\n|\$)}{}}}\
       {(?m)^X-Milter-Del: ([^\\[\\n]+).*}{$1}}
 
   # use greylisting available in rspamd v1.3+


### PR DESCRIPTION
In the modern full exim milter header configuration example, two $s in `set acl_m_milter_add` and `set acl_m_milter_del` respectively need to be escaped otherwise you get an error with the config: `Failed: $ not followed by letter, digit, or {`. 

exim’s string expansion sees $ and tries to interpret it as the start of a variable like `$variable` or `${...}`. When it hits `$}` it complains because `}` is not a valid variable-name character.

To fix it, escape the regex end-of-line anchor so exim passes a literal `$` through to the PCRE engine.