### PR TITLE
Fix exim4 ACL milter header support

### DIFF
--- a/docs/tutorials/integration.md
+++ b/docs/tutorials/integration.md
@@ -282,10 +282,10 @@ acl_check_spam:
   warn
     set acl_m_report     = ${sg{$spam_report}{\\v\\s+}{\\n}}
     set acl_m_milter_add = ${sg{\
-      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Add: ).*(\\n|$)}{}}}\
+      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Add: ).*(\\n|\$)}{}}}\
       {(?m)^X-Milter-Add: ([^\\[:\\n]+)(?:\\[\\d+\\])?: }{$1: }}
     set acl_m_milter_del = ${sg{\
-      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Del: ).*(\\n|$)}{}}}\
+      ${sg{$acl_m_report}{(?m)^(?!X-Milter-Del: ).*(\\n|\$)}{}}}\
       {(?m)^X-Milter-Del: ([^\\[\\n]+).*}{$1}}
 
   # use greylisting available in rspamd v1.3+


### PR DESCRIPTION
I tried to integrate the `full Exim configuration snippet` into my exim4 configuration and got this error message on a test email:

temporarily rejected after 
DATA: failed to expand ACL string "${sg{${sg{$acl_m_report}{(?m)^(?!X-Milter-Add: ).*(\\n|$)}{}}}{(?m)^X-Milte r-Add: ([^\\[:\\n]+)(?:\\[\\d+\\])?: }{$1: }}": $ not followed by letter, digit, or {

It assumed not escaped $ in the expression, which is fixed in this commit. After this change no error message is logged the emails receive as expected.